### PR TITLE
feat(nx-cloud): setup nx workspace

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -4,32 +4,18 @@
     "default": {
       "runner": "nx-cloud",
       "options": {
-        "cacheableOperations": [
-          "build",
-          "lint",
-          "test",
-          "e2e"
-        ],
-        "accessToken": "ZDYyNWU4YzQtOWU3ZC00OGRjLTg2MDgtY2JkNGI1NjY0OTVhfHJlYWQtd3JpdGU="
+        "cacheableOperations": ["build", "lint", "test", "e2e"],
+        "accessToken": "OWM4ZTkxMjgtZGY4ZS00ODg1LWE5NmEtYmY3Mzk1ZGZhYzE2fHJlYWQtd3JpdGU="
       }
     }
   },
   "targetDefaults": {
     "build": {
-      "dependsOn": [
-        "^build"
-      ],
-      "inputs": [
-        "production",
-        "^production"
-      ]
+      "dependsOn": ["^build"],
+      "inputs": ["production", "^production"]
     },
     "test": {
-      "inputs": [
-        "default",
-        "^production",
-        "{workspaceRoot}/jest.preset.js"
-      ]
+      "inputs": ["default", "^production", "{workspaceRoot}/jest.preset.js"]
     },
     "lint": {
       "inputs": [
@@ -40,10 +26,7 @@
     }
   },
   "namedInputs": {
-    "default": [
-      "{projectRoot}/**/*",
-      "sharedGlobals"
-    ],
+    "default": ["{projectRoot}/**/*", "sharedGlobals"],
     "production": [
       "default",
       "!{projectRoot}/**/?(*.)+(spec|test).[jt]s?(x)?(.snap)",


### PR DESCRIPTION
feat(nx-cloud): setup nx cloud workspace 
    
This commit set up Nx Cloud for your Nx workspace enabling distributed caching
and GitHub integration for fast CI and improved Developer Experience.

You can access your Nx Cloud workspace by going to 
https://cloud.nx.app/orgs/66fe963612eb7ec50cd19f95/workspaces/66fe969567bd632d061b2a6b

**Note:** This commit attempts to maintain formatting of the nx.json, however you may need to correct formatting by running an nx format command and committing the changes.